### PR TITLE
refactor!: consolidate into console module

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -1,0 +1,2 @@
+pub use wasm_actions_core::log;
+pub use wasm_actions_log::init;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub mod env;
 mod output;
 pub use output::save_state;
 pub use output::set_output;
-use wasm_actions_core::log;
+pub mod console;
 
 #[macro_export]
 macro_rules! get_input {
@@ -31,5 +31,5 @@ macro_rules! get_state {
 }
 
 pub fn add_mask(value: &str) {
-    log!("::add-mask::{}", value);
+    console::log!("::add-mask::{}", value);
 }


### PR DESCRIPTION
Logging related function and macro are collected in `console` module to clarify their usage.

BREAKING CHANGE:
- wasm-actions will expose `console::log!` macro instead exposing `log!` from the module root.
- wasm-actions will expose `wasm_actions_log::init` function as `console::init`.