### PR TITLE
feat: add wasm-actions-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -307,6 +308,7 @@ dependencies = [
  "log",
  "trybuild",
  "wasm-actions-core",
+ "wasm-actions-derive",
  "wasm-actions-log",
  "wasm-actions-macro",
  "wasm-actions-prelude",
@@ -319,6 +321,24 @@ name = "wasm-actions-core"
 version = "0.3.0"
 dependencies = [
  "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "wasm-actions-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "trybuild",
+ "wasm-actions-core",
+ "wasm-actions-macro",
+ "wasm-actions-prelude",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -347,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-actions-prelude"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "async-once-cell",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,14 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [features]
+default = ["derive"]
+derive = ["wasm-actions-prelude/derive", "wasm-actions-derive"]
 
 [workspace]
 resolver = "2"
 members = [
     "crates/core",
+    "crates/derive",
     "crates/log",
     "crates/macro",
     "crates/prelude"
@@ -19,6 +22,7 @@ members = [
 
 [dependencies]
 wasm-actions-core = { path = "crates/core" }
+wasm-actions-derive = { path = "crates/derive", optional = true }
 wasm-actions-log = { path = "crates/log" }
 wasm-actions-macro = { path = "crates/macro" }
 wasm-actions-prelude = { path = "crates/prelude" }

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -10,3 +10,15 @@ proc-macro = true
 proc-macro2 = "1.0.103"
 quote = "1.0.42"
 syn = "2.0.110"
+wasm-bindgen = { version = "0.2.105", features = ["std"] }
+wasm-bindgen-futures = "0.4.55"
+wasm-actions-core = { path = "../core" }
+wasm-actions-macro = { path = "../macro" }
+wasm-actions-prelude = { path = "../prelude", features = ["derive"] }
+serde_json = "1.0.145"
+
+[dev-dependencies]
+trybuild = "1.0.114"
+wasm-bindgen-test = "0.3.55"
+serde = { version = "1.0.228", features = ["derive"] }
+

--- a/crates/derive/src/codegen.rs
+++ b/crates/derive/src/codegen.rs
@@ -9,13 +9,13 @@ pub(crate) fn start_fn(input: DeriveInput) -> Result<TokenStream, Error> {
     Ok(quote!{
         #[wasm_bindgen::prelude::wasm_bindgen]
         pub async fn start() -> Result<(), wasm_bindgen::prelude::JsError> {
-            use wasm_actions::derive::Action;
+            use wasm_actions_prelude::derive::Action;
             let input = #ident::parse_input()?;
             if let Some(state) = #ident::parse_state()? {
               Ok(#ident::post(input, state).await?)
             } else {
               let output = #ident::main(input).await?;
-              use wasm_actions::derive::ActionOutput;
+              use wasm_actions_prelude::derive::ActionOutput;
               output.save().await?;
               Ok(())
             }
@@ -42,7 +42,7 @@ pub(crate) fn action_input_impl(struct_name: Ident, fields: Vec<InputField>) -> 
         ts.append_all(tokens);
     }
     let out = quote! {
-    impl wasm_actions::derive::ActionInput for #struct_name {
+    impl wasm_actions_prelude::derive::ActionInput for #struct_name {
         fn parse() -> Result<Self, wasm_actions_core::error::Error> {
             Ok(Self {
                 #ts
@@ -59,19 +59,23 @@ fn action_input_field_init(field: InputField) -> Result<TokenStream, Error> {
     let code = match source {
     InputSource::Input(name) => {
         quote! {
-            #field : (wasm_actions::derive::ParseInput::parse(wasm_actions::get_input!(#name).ok_or_else(|| wasm_actions_core::error::Error::from(std::format!("{} missing", #name)))?)?),
+            #field : (wasm_actions_prelude::derive::ParseInput::parse(
+                wasm_actions_prelude::get_input!(#name).ok_or_else(||
+                    wasm_actions_core::error::Error::from(std::format!("{} missing", #name)))?)?),
         }
     },
     InputSource::Env(env) => {
         quote! {
-            #field : (wasm_actions::derive::ParseInput::parse(wasm_actions::env::var(#env).ok_or_else(|| wasm_actions_core::error::Error::from(std::format!("${} missing", #env)))?)?),
+            #field : (wasm_actions_prelude::derive::ParseInput::parse(
+                wasm_actions_prelude::env::var(#env).ok_or_else(||
+                    wasm_actions_core::error::Error::from(std::format!("${} missing", #env)))?)?),
         }
     },
     InputSource::InputThenEnv { input: name, env } => {
         quote! {
-            #field : (wasm_actions::derive::ParseInput::parse(
-                wasm_actions::get_input!(#name).or_else(|_|
-                    wasm_actions::env::var(#env)
+            #field : (wasm_actions_prelude::derive::ParseInput::parse(
+                wasm_actions_prelude::get_input!(#name).or_else(|_|
+                    wasm_actions_prelude::env::var(#env)
                 ).ok_or_else(|| wasm_actions_core::error::Error::from("either {} or ${} missing"))?
             )?),
         }
@@ -94,9 +98,9 @@ pub(crate) fn action_output_impl(struct_name: Ident, fields: Vec<OutputField>) -
     }
 
     let code = quote! {
-        impl wasm_actions::derive::ActionOutput for #struct_name {
+        impl wasm_actions_prelude::derive::ActionOutput for #struct_name {
             fn parse() -> Result<Option<Self>, wasm_actions_core::error::Error> {
-                if let Some(state) = wasm_actions::get_state!("wasm_actions") {
+                if let Some(state) = wasm_actions_prelude::get_state!("wasm_actions") {
                     Ok(Some(serde_json::from_str(&state).map_err(Error::new)?))
                 } else {
                     Ok(None)
@@ -105,7 +109,7 @@ pub(crate) fn action_output_impl(struct_name: Ident, fields: Vec<OutputField>) -
 
             async fn save(self) -> Result<(), wasm_actions_core::error::Error> {
                 let json = serde_json::to_string(&self).map_err(wasm_actions_core::error::Error::new)?;
-                wasm_actions::save_state("wasm_actions", &json).await?;
+                wasm_actions_prelude::save_state("wasm_actions", &json).await?;
                 #ts
                 Ok(())
             }
@@ -118,8 +122,8 @@ fn action_output_set_output(field: OutputField) -> Result<Option<TokenStream>, E
     if let Some(name) = OutputName::try_from(&field.attrs) {
         let struct_field = field.field;
         Ok(Some(quote! {
-            let #struct_field = wasm_actions::derive::StringifyOutput::stringify(self.#struct_field);
-            wasm_actions::set_output(#name, &#struct_field).await?;
+            let #struct_field = wasm_actions_prelude::derive::StringifyOutput::stringify(self.#struct_field);
+            wasm_actions_prelude::set_output(#name, &#struct_field).await?;
         }))
     } else {
         Ok(None)

--- a/crates/derive/src/main.rs
+++ b/crates/derive/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/crates/derive/tests/example.rs
+++ b/crates/derive/tests/example.rs
@@ -1,0 +1,66 @@
+use wasm_actions_macro::input_var;
+use wasm_bindgen::{JsError, JsValue};
+use wasm_bindgen_test::wasm_bindgen_test;
+use wasm_actions_derive::{ wasm_action, ActionInput, ActionOutput };
+use wasm_actions_prelude::derive::Action;
+use wasm_actions_core::{error::Error, process};
+
+#[wasm_action(
+    name = "example",
+    description = "example action"
+)]
+struct Example;
+
+#[derive(ActionInput)]
+struct Input {
+    #[input(
+        name = "foo",
+        required = true,
+        description = "input parameter foo"
+    )]
+    foo: String,
+    #[input(
+        env = "BAR",
+    )]
+    bar: String,
+}
+
+#[derive(ActionOutput, serde::Serialize, serde::Deserialize)]
+struct Output {
+    #[output(name = "message", description = "message from action")]
+    message: String,
+}
+
+impl Action<Input, Output> for Example {
+    async fn main(input: Input) -> Result<Output, Error> {
+        Ok(Output {
+            message: format!("foo = {}, bar = {}", input.foo, input.bar),
+        })
+    }
+}
+
+#[wasm_bindgen_test]
+async fn fail_if_called_without_input() -> Result<(), JsError> {
+    // TODO: reset process.env to ensure the environment clean.
+    if let Err(e) = start().await.map_err(|e| format!("{:?}", JsValue::from(e))) {
+        assert!(e.starts_with("JsValue(Error: foo missing\n"))
+    } else {
+        unreachable!()
+    }
+    Ok(())
+}
+
+// TODO: enable this after we can reset process.env in test.
+// #[wasm_bindgen_test]
+#[allow(dead_code)]
+async fn runs_main_if_inputs_are_filled() -> Result<(), JsError> {
+    process::set_env(input_var!("foo"), "42");
+    process::set_env("BAR", "4242");
+
+    if let Err(e) = start().await.map_err(|e| format!("{:?}", JsValue::from(e))) {
+        unreachable!("{e}")
+    } else {
+        assert!(true)
+    }
+    Ok(())
+}

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["rlib"]
 
+[features]
+derive = []
+
 [dependencies]
 wasm-actions-core = { path = "../core" }
 wasm-actions-log = { path = "../log" }

--- a/crates/prelude/src/derive.rs
+++ b/crates/prelude/src/derive.rs
@@ -1,0 +1,54 @@
+use std::str::FromStr;
+
+use wasm_actions_core::error::Error;
+
+pub trait ActionInput {
+    fn parse() -> Result<Self, Error> where Self: Sized;
+}
+
+pub trait ActionOutput {
+    fn parse() -> Result<Option<Self>, Error> where Self: Sized;
+    #[allow(async_fn_in_trait)]
+    async fn save(self) -> Result<(), Error>;
+}
+
+pub trait Action<I: ActionInput, O: ActionOutput> {
+    fn parse_input() -> Result<I, Error> {
+        I::parse()
+    }
+
+    fn parse_state() -> Result<Option<O>, Error> {
+        O::parse()
+    }
+
+    #[allow(async_fn_in_trait)]
+    async fn main(input: I) -> Result<O, Error>;
+
+    #[allow(async_fn_in_trait)]
+    async fn post(_input: I, _state: O) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+pub trait ParseInput
+where Self: Sized {
+    fn parse(s: String) -> Result<Self, Error>;
+}
+
+impl<T> ParseInput for T
+where T: FromStr + Sized, <T as FromStr>::Err: std::error::Error {
+    fn parse(s: String) -> Result<T, Error> {
+        s.as_str().parse().map_err(|e| Error::new(e))
+    }
+} 
+
+pub trait StringifyOutput {
+    fn stringify(self) -> String;
+}
+
+impl<T> StringifyOutput for T
+where T: Into<String> + Sized {
+    fn stringify(self) -> String {
+        self.into()
+    }
+}

--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -4,6 +4,9 @@ pub use output::save_state;
 pub use output::set_output;
 pub mod console;
 
+#[cfg(feature = "derive")]
+pub mod derive;
+
 #[macro_export]
 macro_rules! get_input {
     ($name:expr) => {


### PR DESCRIPTION
Add derive macro to generate boilerplate code which parses/exports input parameters and state.

This aims to eventually generate `action.yaml` automatically so we will able to write GitHub Actions in pure Rust.