### PR TITLE
feat: add env::remove_var() and env::iter()

### DIFF
--- a/crates/core/src/process.rs
+++ b/crates/core/src/process.rs
@@ -1,4 +1,4 @@
-use js_sys::Reflect;
+use js_sys::{Array, Object, Reflect};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 use crate::io::{WriteStream, StaticWriteStream};
@@ -9,7 +9,7 @@ extern "C" {
     static PROCESS_STDOUT: WriteStream;
 
     #[wasm_bindgen(thread_local_v2, js_name = "env")]
-    static ENV: JsValue;
+    static ENV: Object;
 }
 
 pub fn stdout() -> StaticWriteStream {
@@ -18,13 +18,17 @@ pub fn stdout() -> StaticWriteStream {
 
 pub fn get_env(key: &str) -> Option<String> {
     let key = JsValue::from_str(key);
+    get_env_by_jsvalue(&key)
+}
+
+fn get_env_by_jsvalue(key: &JsValue) -> Option<String> {
     let value= ENV.with(move |env| {Reflect::get(env, &key) });
 
     if let Ok(value) = value {
         value.as_string()
     } else {
         None
-    }
+    }   
 }
 
 pub fn set_env(key: &str, value: &str) {
@@ -36,6 +40,58 @@ pub fn set_env(key: &str, value: &str) {
     }).unwrap();
 }
 
+pub fn delete_env(key: &str) {
+    let key = JsValue::from_str(key);
+    let _ = ENV.with(move |env| {
+        Reflect::delete_property(env, &key)
+    });
+}
+
+pub struct EnvIterator {
+    keys: Array,
+    next_index: u32,
+    last_index: u32,
+}
+
+impl EnvIterator {
+    pub fn new() -> Self {
+        let keys = ENV.with(move |env| {
+            Object::keys(env)
+        });
+        let last_index = keys.length();
+        Self {
+            keys,
+            next_index: 0,
+            last_index
+        }
+    }
+}
+
+impl Iterator for EnvIterator {
+    type Item = (String, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.next_index >= self.last_index {
+                break
+            }
+            let key = self.keys.get(self.next_index);
+            let key_s = key.as_string().expect("key of process.env is expected to be a string");
+            self.next_index += 1;
+
+            // skip missing key.
+            // ENV can be mutated while iterating over keys.
+            // And we don't want to copy all the values in environment variables at initialization of EnvIterator. 
+            if let Some(entry) = get_env_by_jsvalue(&key).map(|val| (key_s, val)) {
+                return Some(entry)
+            }
+        }
+
+        None
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -44,5 +100,9 @@ mod tests {
     fn test_env() {
         set_env("TEST_KEY", "TEST_VALUE");
         assert_eq!(get_env("TEST_KEY"), Some("TEST_VALUE".to_string()));
+        assert_eq!(EnvIterator::new().find(|(k, _v)| k == "TEST_KEY"), Some((String::from("TEST_KEY"), String::from("TEST_VALUE"))));
+        delete_env("TEST_KEY");
+        assert_eq!(get_env("TEST_KEY"), None);
+        assert_eq!(EnvIterator::new().find(|(k, _v)| k == "TEST_KEY"), None);
     }
 }

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["rlib"]
 
 [features]
 derive = []
+testing = []
 
 [dependencies]
 wasm-actions-core = { path = "../core" }

--- a/crates/prelude/src/env.rs
+++ b/crates/prelude/src/env.rs
@@ -1,4 +1,4 @@
-use wasm_actions_core::process;
+use wasm_actions_core::process::{self, EnvIterator};
 
 pub fn var(name: &str) -> Option<String> {
     process::get_env(name)
@@ -6,4 +6,12 @@ pub fn var(name: &str) -> Option<String> {
 
 pub fn set_var(name: &str, value: &str) {
     process::set_env(name, value);
+}
+
+pub fn remove_var(name: &str) {
+    process::delete_env(name);
+}
+
+pub fn vars() -> EnvIterator {
+    EnvIterator::new()
 }

--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -7,6 +7,9 @@ pub mod console;
 #[cfg(feature = "derive")]
 pub mod derive;
 
+#[cfg(feature = "testing")]
+pub mod testing;
+
 #[macro_export]
 macro_rules! get_input {
     ($name:expr) => {

--- a/crates/prelude/src/testing.rs
+++ b/crates/prelude/src/testing.rs
@@ -1,0 +1,22 @@
+use crate::env;
+
+pub struct ClearEnvGuard {
+    envs: Vec<(String, String)>
+}
+
+impl Drop for ClearEnvGuard {
+    fn drop(&mut self) {
+        for (k, _) in env::vars() {
+            env::remove_var(&k);
+        }
+        for (k, v) in self.envs.iter() {
+            env::set_var(k, v);
+        }
+    }
+}
+
+pub fn clear_env() -> ClearEnvGuard {
+    ClearEnvGuard {
+        envs: env::vars().collect()
+    }
+}


### PR DESCRIPTION
- Add `env::remove_var()` to prelude, alike `std::env::remove_var()`
- Add `env::vars()` to prelude, alike `std::env::vars()`
- Add `testing::clear_env()` to prelude, it can be use to restore environment variables polluted by test cases.