### PR TITLE
feat: env::runner_temp_dir()

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod process;
 pub mod io;
 pub mod promise;
 pub mod fs;
+pub mod os;
 
 #[macro_export]
 macro_rules! log {

--- a/crates/core/src/os.rs
+++ b/crates/core/src/os.rs
@@ -1,0 +1,7 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(module = "node:os")]
+extern "C" {
+    #[wasm_bindgen(js_name = "tmpdir")]
+    pub fn tmpdir() -> String;
+}

--- a/crates/prelude/src/env.rs
+++ b/crates/prelude/src/env.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use wasm_actions_core::process::{self, EnvIterator};
+use wasm_actions_core::{os, process::{self, EnvIterator}};
 
 pub fn var(name: &str) -> Option<String> {
     process::get_env(name)
@@ -19,7 +19,12 @@ pub fn vars() -> EnvIterator {
 }
 
 pub fn temp_dir() -> PathBuf {
+    PathBuf::from(os::tmpdir())
+}
+
+pub fn runner_temp_dir() -> PathBuf {
     // https://docs.github.com/en/actions/reference/workflows-and-actions/variables
     let runner_temp = var("RUNNER_TEMP").expect("$RUNNER_TEMP is expected to be set");
     PathBuf::from(runner_temp)
 }
+


### PR DESCRIPTION
Add `env::runner_temp_dir()` which resolved to `$RUNNER_TEMP` path.
BREAKING CHANGE: `env::temp_dir()` changed to return Node's `os.tmpdir()` instead.