### PR TITLE
fix: address std::io::Write reimported error

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,13 +8,17 @@ pub mod os;
 #[macro_export]
 macro_rules! log {
     () => {
-        use std::io::Write;
-        let mut stdout = $crate::process::stdout();
-        let _ = std::writeln!(&mut stdout);
+        {
+            use std::io::Write;
+            let mut stdout = $crate::process::stdout();
+            let _ = std::writeln!(&mut stdout);
+        }
     };
     ($($arg:tt)*) => {
-        use std::io::Write;
-        let mut stdout = $crate::process::stdout();
-        let _ = std::writeln!(&mut stdout, $($arg)*);
+        {
+            use std::io::Write;
+            let mut stdout = $crate::process::stdout();
+            let _ = std::writeln!(&mut stdout, $($arg)*);
+        }
     };
 }


### PR DESCRIPTION
fix this:

```rust
log!("foo");
log!("bar"); // error
```
